### PR TITLE
Add wordCounter

### DIFF
--- a/lib/wordCounter.js
+++ b/lib/wordCounter.js
@@ -1,0 +1,40 @@
+var wordCounter = function (markdown) {
+  var ignoreCount = false;
+  var count = 0;
+  if (!markdown) {
+    return count;
+  }
+  markdown.split('\n').forEach(function (line) {
+    //もし```か[jade]であれば、次の```か[/jade]まで無視
+    if (/^(```|\[\/?jade\])/.test(line)) {
+      ignoreCount = !ignoreCount ? true : false ;
+    }
+    if (ignoreCount) {
+      return;
+    }
+    //不要な文字を消して数えたい文字列のみにする
+    var filteredText = line
+      // タグ
+      .replace(/<("[^"]*"|'[^']*'|[^'">])*>/g, '')
+      // 引用
+      .replace(/^>.+/g, '')
+      // [note]などの独自記法
+      .replace(/^\[.+\]$/g, '')
+      // 画像
+      .replace(/!\[.+\]\(.+\)/g, '')
+      // リンクはタイトルを残す
+      .replace(/\[(.+)\]\(.+\)/g, '$1')
+      // 装飾記号
+      .replace(/[#\-+*_`]/g, '')
+      // 行頭の空白
+      .replace(/^\s+/g, '')
+      // 改行
+      .replace(/\n+/g, '')
+    if (filteredText.length) {
+      count += filteredText.length;
+    }
+  });
+  return count;
+};
+
+module.exports = wordCounter;

--- a/main.js
+++ b/main.js
@@ -7,6 +7,7 @@ const ipcMain = require('electron').ipcMain;
 const path = require('path');
 const TextLintEngine = require('textlint').TextLintEngine;
 const temp = require('temp');
+const wordCounter = require('./lib/wordCounter');
 
 var __tempDirPath;
 var __textlintConfigPath;
@@ -148,7 +149,7 @@ function updatePreview(filePath) {
     mainWindow.webContents.send('open-markdown', {
       md: file,
       path: filePath,
-      count: file.length
+      count: wordCounter(file)
     });
   });
 }


### PR DESCRIPTION
Markdownファイル内の文字数では、見出し記号など余計なものが含まれるため、一部の文字をカウントしないようにしてみました。

右下に表示される文字数としてカウントされないもの
- 見出しの `#` や、リストの `-`
- HTMLタグ
- コードフェンスと、その中身
- `[jade]`〜`[/jade]`
- 改行や空白
- `*_`などの装飾記号
- `![](http://...)`インライン画像
- `[リンク](http://...)` のURL部分
- `>` から始まる引用

実装の際にプレビューで使用したファイルは [1.txt](https://github.com/nakajmg/cgmd-preview/files/232915/1.txt)です。 (拡張子をmdにして確認)
